### PR TITLE
vda: fix crash when a frame is dropped.

### DIFF
--- a/libavcodec/vda.h
+++ b/libavcodec/vda.h
@@ -41,6 +41,12 @@
 
 #include "libavcodec/version.h"
 
+// extra flags not defined in VDADecoder.h
+enum {
+    kVDADecodeInfo_Asynchronous = 1UL << 0,
+    kVDADecodeInfo_FrameDropped = 1UL << 1
+};
+
 /**
  * @defgroup lavc_codec_hwaccel_vda VDA
  * @ingroup lavc_codec_hwaccel

--- a/libavcodec/vda_h264.c
+++ b/libavcodec/vda_h264.c
@@ -41,6 +41,9 @@ static void vda_decoder_callback (void *vda_hw_ctx,
 {
     struct vda_context *vda_ctx = vda_hw_ctx;
 
+    if (infoFlags & kVDADecodeInfo_FrameDropped)
+        vda_ctx->cv_buffer = NULL;
+
     if (!image_buffer)
         return;
 


### PR DESCRIPTION
When frame dropping occurs, vda will return the same buffer more than once, which may cause caller to retain a released buffer.
